### PR TITLE
Relating `build` & `install`, Adding `clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
+RM ?= /bin/rm
 PYTHON ?= /usr/local/bin/python2.7
 PREFIX ?= /usr/local
 
 build:
 	${PYTHON} setup.py build
 
-install:
+install: build
 	${PYTHON} setup.py install --prefix ${PREFIX}
+
+clean:
+        ${PYTHON} setup.py clean
+        ${RM} -rf build launchd.c


### PR DESCRIPTION
This adds `clean` target to Makefile.
Also establishes correct relationship between `install` and `build` targets.
